### PR TITLE
Extend the `Subset` annotation class to support simpler cases

### DIFF
--- a/autogoal/grammar/_cfg.py
+++ b/autogoal/grammar/_cfg.py
@@ -100,7 +100,7 @@ class SubsetOf(Production):
         self, code: List[str], visited: Set[Symbol], max_symbol_length: int,
     ):
         lhs = ("<%s>" % self.head.name).ljust(max_symbol_length)
-        rhs = ["<%s>" % option.name for option in self._options]
+        rhs = [("<%s>" % option.name if hasattr(option, "name") else repr(option)) for option in self._options]
 
         code.append("%s := { %s }" % (lhs, " , ".join(rhs)))
         visited.add(self.head)
@@ -440,8 +440,7 @@ class Subset:
                 children.append(child_symbol)
                 _generate_cfg(child, grammar, child_symbol)
             else:
-                child_symbol = Symbol(str(child))
-                children.append(child_symbol)
+                children.append(child)
 
         grammar.replace(symbol, SubsetOf(symbol, grammar, *children, allow_empty=self.allow_empty))
         return grammar

--- a/autogoal/grammar/_cfg.py
+++ b/autogoal/grammar/_cfg.py
@@ -86,11 +86,11 @@ class OneOf(Production):
 class SubsetOf(Production):
     def __init__(self, head, grammar, *options, allow_empty=False):
         super().__init__(head, grammar)
-        self._options: List[Symbol] = list(options)
+        self._options: List[object] = list(options)
         self._allow_empty = allow_empty
 
     @property
-    def options(self) -> List[Symbol]:
+    def options(self) -> List[object]:
         return self._options
 
     def __repr__(self):
@@ -122,8 +122,15 @@ class SubsetOf(Production):
             selected = []
 
             for option in self.options:
-                if sampler.boolean(handle=self.head.name + "_" + option.name):
-                    selected.append(self.grammar[option].sample(sampler, namespace, max_iterations-1))
+                if hasattr(option, "name"):
+                    handle = self.head.name + "_" + option.name
+                    sample = self.grammar[option].sample(sampler, namespace, max_iterations-1)
+                else:
+                    handle = self.head.name + "_" + repr(option)
+                    sample = option
+
+                if sampler.boolean(handle=handle):
+                    selected.append(sample)
 
             if len(selected) > 0 or self._allow_empty:
                 break

--- a/tests/core/test_grammar.py
+++ b/tests/core/test_grammar.py
@@ -1,4 +1,4 @@
-import textwrap
+from autogoal.sampling import Sampler
 
 from autogoal.grammar import Discrete, generate_cfg, Subset, Categorical
 
@@ -37,7 +37,7 @@ def test_subset_annotation_with_constants():
     check_grammar(
         generate_cfg(A),
         """
-        <A>    := A (features=<Subset>)
+        <A>      := A (features=<Subset>)
         <Subset> := { 'Hello' , 'World' , 1 }
         """,
     )
@@ -50,7 +50,7 @@ def test_subset_annotation_with_callables():
     check_grammar(
         generate_cfg(A),
         """
-        <A>    := A (features=<Subset>)
+        <A>      := A (features=<Subset>)
         <Subset> := { Discrete(min=1, max=5) , Categorical('adam', 'sgd') }
         """,
     )
@@ -63,10 +63,34 @@ def test_subset_annotation():
     check_grammar(
         generate_cfg(A),
         """
-        <A>    := A (features=<Subset>)
+        <A>      := A (features=<Subset>)
         <Subset> := { Discrete(min=1, max=5) , 'Hello' , 1 , None }
         """,
     )
+
+def test_subset_annotation():
+    class A:
+        def __init__(self, features: Subset('Subset', Discrete(1, 5), 'Hello', 1, None)):
+            pass
+
+    check_grammar(
+        generate_cfg(A),
+        """
+        <A>      := A (features=<Subset>)
+        <Subset> := { Discrete(min=1, max=5) , 'Hello' , 1 , None }
+        """,
+    )
+
+def test_sample_subset():
+    class A:
+        def __init__(self, features: Subset('Subset', Discrete(1, 5), 'Hello', 1, None)):
+            self.features = features
+
+    g = generate_cfg(A)
+    selected_features = g.sample().features
+    selected = set([repr(feature) for feature in selected_features])
+    assert selected.issubset([repr(feature) for feature in [Discrete(1, 5), 'Hello', 1, None]])
+
 
 def test_generate_from_method():
     def f():

--- a/tests/core/test_grammar.py
+++ b/tests/core/test_grammar.py
@@ -1,6 +1,6 @@
 import textwrap
 
-from autogoal.grammar import Discrete, generate_cfg
+from autogoal.grammar import Discrete, generate_cfg, Subset
 from autogoal.sampling import Sampler
 
 
@@ -27,6 +27,19 @@ def test_generate_from_class_with_args():
         """
         <A>   := A (x=<A_x>)
         <A_x> := discrete (min=1, max=5)
+        """,
+    )
+
+def test_subset_annotation():
+    class A:
+        def __init__(self, features: Subset('Test', "Hello", "World")):
+            pass
+
+    check_grammar(
+        generate_cfg(A),
+        """
+        <A>   := A (features=<Test>)
+        <Test> := { <Hello> , <World> }
         """,
     )
 

--- a/tests/core/test_grammar.py
+++ b/tests/core/test_grammar.py
@@ -1,7 +1,6 @@
 import textwrap
 
-from autogoal.grammar import Discrete, generate_cfg, Subset
-from autogoal.sampling import Sampler
+from autogoal.grammar import Discrete, generate_cfg, Subset, Categorical
 
 
 def check_grammar(g, s):
@@ -30,19 +29,44 @@ def test_generate_from_class_with_args():
         """,
     )
 
-def test_subset_annotation():
+def test_subset_annotation_with_constants():
     class A:
-        def __init__(self, features: Subset('Test', "Hello", "World")):
+        def __init__(self, features: Subset('Subset', "Hello", "World", 1)):
             pass
 
     check_grammar(
         generate_cfg(A),
         """
-        <A>   := A (features=<Test>)
-        <Test> := { <Hello> , <World> }
+        <A>    := A (features=<Subset>)
+        <Subset> := { 'Hello' , 'World' , 1 }
         """,
     )
 
+def test_subset_annotation_with_callables():
+    class A:
+        def __init__(self, features: Subset('Subset', Discrete(1, 5), Categorical('adam', 'sgd'))):
+            pass
+
+    check_grammar(
+        generate_cfg(A),
+        """
+        <A>    := A (features=<Subset>)
+        <Subset> := { Discrete(min=1, max=5) , Categorical('adam', 'sgd') }
+        """,
+    )
+
+def test_subset_annotation():
+    class A:
+        def __init__(self, features: Subset('Subset', Discrete(1, 5), 'Hello', 1, None)):
+            pass
+
+    check_grammar(
+        generate_cfg(A),
+        """
+        <A>    := A (features=<Subset>)
+        <Subset> := { Discrete(min=1, max=5) , 'Hello' , 1 , None }
+        """,
+    )
 
 def test_generate_from_method():
     def f():


### PR DESCRIPTION
This PR updates the `Subset` class and adds three new unit tests, as requested in https://github.com/autogoal/autogoal/issues/7.

Some improvements might be:

* Maybe three unit tests are too much? `test_subset_annotation` already covers the two cases, but we could argue that we have more granular info in case something breaks...
* The pretty-printing of the constants could be improved (by maybe adding a new separate class (`Constant`?) to model constant arguments).
* `if type(child) is Callable` could maybe be changed to `if isinstance(child, Callable)`?