### PR TITLE
General Bug fixes

### DIFF
--- a/autogoal/grammar/_cfg.py
+++ b/autogoal/grammar/_cfg.py
@@ -312,7 +312,10 @@ def _generate_cfg(
     parameters = {}
 
     if inspect.isclass(cls):
-        signature = inspect.signature(cls.__init__)
+        if getattr(cls, "get_inner_signature", None):
+            signature = cls.get_inner_signature()
+        else:
+            signature = inspect.signature(cls.__init__)
     elif inspect.isfunction(cls):
         signature = inspect.signature(cls)
     else:

--- a/autogoal/kb/_algorithm.py
+++ b/autogoal/kb/_algorithm.py
@@ -162,19 +162,6 @@ class Algorithm(abc.ABC):
         return True
 
 
-class SeqWrapper(abc.ABC):
-    """ Represents an abstract sequence algorithm wrapper
-
-    The class provides methods that should be implemented by sequence algorithms
-    """
-
-    @abc.abstractclassmethod
-    def get_inner_signature(cls) -> inspect.Signature:
-        """ Gets the signature of the inner class __init__ method.
-        """
-        pass
-
-
 class AlgorithmBase(Algorithm):
     """Represents an algorithm,
 
@@ -312,7 +299,8 @@ def make_seq_algorithm(algorithm: Algorithm):
     Seq[<class 'float'>]
     >>> build_input_args(B, {Seq[int]: [1, 2], Seq[str]: ["hello", "world"]})
     {'x': [1, 2], 'y': ['hello', 'world']}
-    
+    >>> b.get_inner_signature()
+    <Signature (self, alpha)>
     """
 
     output_type = algorithm.output_type()
@@ -360,7 +348,7 @@ def make_seq_algorithm(algorithm: Algorithm):
         ns["output_type"] = output_types_method
         ns["get_inner_signature"] = get_inner_signature_method
 
-    return types.new_class(name=name, bases=(Algorithm, SeqWrapper), exec_body=body)
+    return types.new_class(name=name, bases=(Algorithm,), exec_body=body)
 
 
 Akw = namedtuple("Akw", ["args", "kwargs"])

--- a/autogoal/ml/_automl.py
+++ b/autogoal/ml/_automl.py
@@ -136,14 +136,18 @@ class AutoML:
             scores = []
 
             for _ in range(self.cross_validation_steps):
-                len_x = len(X) if isinstance(X, list) else X.shape[0]
+                len_x = (
+                    len(X)
+                    if isinstance(X, list) or isinstance(X, tuple)
+                    else X.shape[0]
+                )
                 indices = np.arange(0, len_x)
                 np.random.shuffle(indices)
                 split_index = int(self.validation_split * len(indices))
                 train_indices = indices[:-split_index]
                 test_indices = indices[-split_index:]
 
-                if isinstance(X, list):
+                if isinstance(X, list) or isinstance(X, tuple):
                     X_train, y_train, X_test, y_test = (
                         [X[i] for i in train_indices],
                         y[train_indices],

--- a/autogoal/search/_base.py
+++ b/autogoal/search/_base.py
@@ -106,7 +106,7 @@ class SearchAlgorithm:
                         logger.sample_solution(solution)
                         fn = self._fitness_fn(solution)
                     except Exception as e:
-                        fn = 0.0
+                        fn = -math.inf if self._maximize else math.inf
                         logger.error(e, solution)
 
                         if self._errors == "raise":


### PR DESCRIPTION
1. The search algorithm is using 0 as the error value. Although it works for hyperparameter tuning in supervised learning, where the  accuracy can never be a negative number, it may fail in other circumstances. Changed it to use `-inf` or `inf` depending on wether the search function is to be minimized or maximized.
2.  `make_fitness_fn` is treating tuples the same way as numpy arrays. This PR fixes this by checking if the input type is a tuple and treats it the same way as lists.
3. This last one is more complex. I noticed that some nodes added to a pipeline were redundant. For example, in a pipeline where the input is A and the output is C, a possible pipeline would be `A -> B, B -> C`. But the pipeline builder would also find pipelines that generated completely redundant data types like `A -> B, A -> D, B -> C` (there is no need for an algorithm that generates the D data type in the pipeline). The solution I came up with is quite simple: just use a new algorithm if at least one of it's inputs was the last node's output. There is a specific case where this would fail. If there is an algorithm that needs both `B` and `D` to generate `C`, then it would be something like `A -> B, A -> D, (B,D) -> C`. But the second node does not use the output of the previous one, which would be `B` and so this pipeline would not be created. I do believe though that this is an extremely rare situation, and that the overhead of generating a lot of redundant nodes justifies this change.